### PR TITLE
Auto-spoof mode for dnsmasq

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Without an *armor*, configuration is appended at end of file, specifying `eth0` 
 | `tld`        | `string`   | no | Search (top-level) *domain* to set via DHCP. Defaults to `offspot`                                               |
 | `domain`     | `string`   | no | Domain name to direct to the offspot. Defaults to `generic` (resolved as `generic.{tld}`                         |
 | `welcome`    | `string`   | no | Additional domain to direct to offspot. Defaults to `goto.kiwix` (resolved as `goto.generic.{tld}`               |
-| `spoof`      | `boolean`  | no | Whether to direct all DNS requests to the offspot. Useful for captive-portal without Internet bridge             |
+| `spoof`      | `boolean`* | no | Whether to direct all DNS requests to the offspot. Useful for captive-portal without Internet bridge. Special value `auto` triggers it when the hotspot is offline and disables it when it is connected to Internet    |
 
 ### notes
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
             "offspot-config-ethernet=offspot_runtime_config.ethernet:entrypoint",
             "offspot-config-hostname=offspot_runtime_config.hostname:entrypoint",
             "offspot-config-timezone=offspot_runtime_config.timezone:entrypoint",
+            "toggle-dnsmasq-spoof=offspot_runtime_config.dnsmasqspoof:entrypoint",
             "offspot-config-fromfile=offspot_runtime_config.fromfile:entrypoint",
         ]
     },

--- a/src/offspot_runtime_config/dnsmasqspoof.py
+++ b/src/offspot_runtime_config/dnsmasqspoof.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+""" Toggle dnsmasq's spoof mode when internet connection is offline """
+
+import argparse
+import inspect
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Optional
+
+parent = pathlib.Path(inspect.getfile(inspect.currentframe())).parent.resolve()
+if parent not in sys.path:
+    sys.path.insert(0, str(parent))
+
+from offspot_config_lib import (  # noqa: E402
+    DNSMASQ_SPOOF_CONFIG_PATH,
+    Config,
+    __version__,
+    ensure_folder,
+    fail_error,
+    restart_service,
+    succeed,
+    warn_unless_root,
+)
+
+NAME = pathlib.Path(__file__).stem
+INTERNET_STATUS_PATH = pathlib.Path("/var/run/internet")
+
+Config.init(NAME)
+logger = Config.logger
+
+
+def toggle_dnsmasq(dnsmasq_conf_path: pathlib.Path, spoof: bool):
+    """wether spoof file has been changed"""
+
+    ensure_folder(dnsmasq_conf_path.parent)
+    with open(dnsmasq_conf_path, "r") as fh:
+        content = fh.read()
+
+    is_spoof = False
+    for line in content.splitlines():
+        if line.startswith("address=/#/"):
+            is_spoof = True
+            break
+
+    if (spoof and is_spoof) or (not spoof and not is_spoof):
+        logger.info(f"already in correct mode: {is_spoof=} {spoof=}")
+        return False
+
+    logger.info(f"toggling from {is_spoof=} into {spoof=}")
+
+    # turning non-spoof into spoof by removing comment on address
+    if spoof and not is_spoof:
+        for line in content.splitlines():
+            m = re.match(r"^\s*#\s+(?P<line>address=/#/.+)$", line)
+            if m:
+                content = f"{m.groupdict()['line']}\n"
+                break
+
+    # turning spoof into non-spoof
+    else:
+        for line in content.splitlines():
+            if line.startswith("address=/#/"):
+                content = f"# {line}\n"
+                break
+
+    with open(dnsmasq_conf_path, "w") as fh:
+        fh.write(content)
+
+    return True
+
+
+def restart_dnsmasq():
+    return subprocess.run(["/usr/bin/systemctl", "restart", "dnsmasq"]).returncode == 0
+
+
+def main(debug: Optional[bool] = False):
+    warn_unless_root()
+
+    spoof = False
+    try:
+        with open(INTERNET_STATUS_PATH, "r") as fh:
+            status = fh.read().strip()
+        spoof = status != "online"
+    except Exception as exc:
+        fail_error(
+            f"unable to read Internet connection status "
+            f"from {INTERNET_STATUS_PATH}: {exc}"
+        )
+    try:
+        fixed = toggle_dnsmasq(dnsmasq_conf_path=DNSMASQ_SPOOF_CONFIG_PATH, spoof=spoof)
+    except Exception as exc:
+        fail_error(
+            "unable to read/write dnsmasq spoof config "
+            f"at {DNSMASQ_SPOOF_CONFIG_PATH}: {exc}"
+        )
+    if not fixed:
+        return
+
+    if restart_service("dnsmasq") != 0:
+        fail_error("failed to restart dnsmasq")
+
+    succeed("toggled spoof mode")
+
+
+def entrypoint():
+    parser = argparse.ArgumentParser(
+        prog=NAME,
+        description="Toggle dnsmasq's spoof mode based on internet connectivity",
+    )
+    parser.add_argument("-V", "--version", action="version", version=__version__)
+    parser.add_argument("--debug", action="store_true", dest="debug")
+
+    kwargs = dict(parser.parse_args()._get_kwargs())
+    Config.set_debug(kwargs.get("debug"))
+
+    try:
+        sys.exit(main(**kwargs))
+    except Exception as exc:
+        if Config.debug:
+            logger.exception(exc)
+        else:
+            logger.error(exc)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(entrypoint())

--- a/src/offspot_runtime_config/fromfile.py
+++ b/src/offspot_runtime_config/fromfile.py
@@ -155,11 +155,12 @@ class Handlers:
             "interface",
             "dhcp-range",
             "network",
+            "spoof",
         ):
             if item.get(key) is not None:
                 command += [f"--{key}", str(item.get(key))]
 
-        for key in ("hide", "as-gateway", "spoof"):
+        for key in ("hide", "as-gateway"):
             if item.get(key):
                 command += [f"--{key}"]
 


### PR DESCRIPTION
Spoofing DNS responses or not is crucial to make the captive portal work:
- when in an online scenario where we route regular internet traffic, we must not spoof or users will face the captive portal and not browse internet.
- when in offline scenario, returning valid (although spoofed) DNS responses is mandatory for clients to make following http requests and reach the portal then eventualy the hotspot.

those two modes are thus incompatible and the previous boolean configuration is fine as long as the admin sets the correct mode and the environment doesn't change.

A realworld usecase though is a box that may or may not be connected to internet. This `auto` mode allows this by toggling the DNS behavior based on the internet connectivity status (provided by upstream/base-image)

This is done by calling a new conf-file from the main dnsmasq conf and pointing it to /etc/dnsmasq-spoof.conf
Content of this file is different wether spoof was requested or not. It's a single line of conf that enables spoofing when enabled and commented when not.

The IP returned when spoofing is an external IP (Cloudflare) on purpose as we want offline clients to attempt real request so it traverses our router and get intercepted and dnated to our captive portal

The toggling mechanism of `auto` attaches a systemd path watcher on /var/run/internet and runs the toggle script based on its content.